### PR TITLE
SLING-8310 mimetypes Web Console Printer broken

### DIFF
--- a/src/main/java/org/apache/sling/commons/mime/internal/MimeTypeWebConsolePlugin.java
+++ b/src/main/java/org/apache/sling/commons/mime/internal/MimeTypeWebConsolePlugin.java
@@ -45,7 +45,7 @@ import org.osgi.service.component.annotations.Reference;
                 "felix.webconsole.css=" + MimeTypeWebConsolePlugin.CSS_REFS
         }
         )
-class MimeTypeWebConsolePlugin extends HttpServlet {
+public class MimeTypeWebConsolePlugin extends HttpServlet {
 
     /** Serial Version */
     private static final long serialVersionUID = -2025952303202431607L;


### PR DESCRIPTION
* class was made an OSGi `@Component` via SLING-7612 [0], but wasn't made
* `public`, thus SCR wasn't able to instantiate it

[0] https://github.com/apache/sling-org-apache-sling-commons-mime/commit/4606f104d9fc15ab1681c125a0abcd7096dfcbdb