### PR TITLE
SLING-11651 - support for multiple mime types for eps

### DIFF
--- a/src/main/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImpl.java
+++ b/src/main/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImpl.java
@@ -130,8 +130,7 @@ public class MimeTypeServiceImpl implements MimeTypeService, BundleListener {
 
     @Override
     public void registerMimeType(String mimeType, String... extensions) {
-        if (mimeType == null || mimeType.length() == 0 || extensions == null
-            || extensions.length == 0) {
+        if (isNullOrEmpty(mimeType) || extensions == null || extensions.length == 0) {
             return;
         }
 
@@ -141,7 +140,7 @@ public class MimeTypeServiceImpl implements MimeTypeService, BundleListener {
         String firstExtension = null;
 
         for (String extension : extensions) {
-            if (extension != null && extension.length() > 0) {
+            if (!isNullOrEmpty(extension)) {
                 extension = extension.toLowerCase();
                 if(firstExtension == null) {
                     firstExtension = extension;
@@ -171,6 +170,10 @@ public class MimeTypeServiceImpl implements MimeTypeService, BundleListener {
             }
         }
         addToExtensions(defaultExtension, mimeType, firstExtension);
+    }
+
+    private boolean isNullOrEmpty(String value) {
+        return (value == null || value.length() == 0);
     }
 
     private void addToExtensions(String defaultExtension, String mimeType, String extension) {

--- a/src/main/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImpl.java
+++ b/src/main/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImpl.java
@@ -140,33 +140,25 @@ public class MimeTypeServiceImpl implements MimeTypeService, BundleListener {
         String firstExtension = null;
 
         for (String extension : extensions) {
-            if (!isNullOrEmpty(extension)) {
-                extension = extension.toLowerCase();
-                if(firstExtension == null) {
-                    firstExtension = extension;
+            if (isNullOrEmpty(extension)) {
+                continue;
+            }
+            extension = extension.toLowerCase();
+            if(firstExtension == null) {
+                firstExtension = extension;
+            }
+
+            String oldMimeType = mimeMap.get(extension);
+            if (oldMimeType == null) {
+
+                log.debug("registerMimeType: Add mapping "
+                    + extension + "=" + mimeType);
+
+                this.mimeMap.put(extension, mimeType);
+
+                if (defaultExtension == null) {
+                    defaultExtension = extension;
                 }
-
-                String oldMimeType = mimeMap.get(extension);
-                if (oldMimeType == null) {
-
-                    log.debug("registerMimeType: Add mapping "
-                        + extension + "=" + mimeType);
-
-                    this.mimeMap.put(extension, mimeType);
-
-                    if (defaultExtension == null) {
-                        defaultExtension = extension;
-                    }
-
-                } else {
-
-                    log.info(
-                        "registerMimeType: Ignoring mapping " + extension + "="
-                            + mimeType + ": Mapping " + extension + "="
-                            + oldMimeType + " already exists");
-
-                }
-
             }
         }
         addToExtensions(defaultExtension, mimeType, firstExtension);

--- a/src/main/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImpl.java
+++ b/src/main/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImpl.java
@@ -134,9 +134,8 @@ public class MimeTypeServiceImpl implements MimeTypeService, BundleListener {
             return;
         }
 
-        mimeType = mimeType.toLowerCase();
-
-        String defaultExtension = extensionMap.get(mimeType);
+        String mimeType2 = mimeType.toLowerCase();
+        String defaultExtension = extensionMap.get(mimeType2);
         String firstExtension = null;
 
         for (String extension : extensions) {
@@ -148,20 +147,14 @@ public class MimeTypeServiceImpl implements MimeTypeService, BundleListener {
                 firstExtension = extension;
             }
 
-            String oldMimeType = mimeMap.get(extension);
-            if (oldMimeType == null) {
-
-                log.debug("registerMimeType: Add mapping "
-                    + extension + "=" + mimeType);
-
-                this.mimeMap.put(extension, mimeType);
-
+            if (mimeMap.computeIfAbsent(extension, k -> mimeType2) != null) {
+                log.debug("registerMimeType: Add mapping {}={}", extension, mimeType2);
                 if (defaultExtension == null) {
                     defaultExtension = extension;
                 }
             }
         }
-        addToExtensions(defaultExtension, mimeType, firstExtension);
+        addToExtensions(defaultExtension, mimeType2, firstExtension);
     }
 
     private boolean isNullOrEmpty(String value) {

--- a/src/main/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImpl.java
+++ b/src/main/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImpl.java
@@ -167,8 +167,13 @@ public class MimeTypeServiceImpl implements MimeTypeService, BundleListener {
             }
         }
 
+        String extension = extensions[0];
         if (defaultExtension != null) {
             this.extensionMap.put(mimeType, defaultExtension);
+            // support multiple mime types to an extension
+        } else if (extensionMap.get(mimeType) == null && extension != null && extension.length() > 0) {
+            extension = extension.toLowerCase();
+            this.extensionMap.put(mimeType, extension);
         }
     }
 

--- a/src/main/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImpl.java
+++ b/src/main/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImpl.java
@@ -138,10 +138,14 @@ public class MimeTypeServiceImpl implements MimeTypeService, BundleListener {
         mimeType = mimeType.toLowerCase();
 
         String defaultExtension = extensionMap.get(mimeType);
+        String firstExtension = null;
 
         for (String extension : extensions) {
             if (extension != null && extension.length() > 0) {
                 extension = extension.toLowerCase();
+                if(firstExtension == null) {
+                    firstExtension = extension;
+                }
 
                 String oldMimeType = mimeMap.get(extension);
                 if (oldMimeType == null) {
@@ -166,17 +170,15 @@ public class MimeTypeServiceImpl implements MimeTypeService, BundleListener {
 
             }
         }
-        addToExtensions(defaultExtension, mimeType, extensions);
+        addToExtensions(defaultExtension, mimeType, firstExtension);
     }
 
-    private void addToExtensions(String defaultExtension, String mimeType, String[] extensions) {
-        String extension = extensions[0];
+    private void addToExtensions(String defaultExtension, String mimeType, String extension) {
         if (defaultExtension != null) {
             this.extensionMap.put(mimeType, defaultExtension);
+        } else {
             // support multiple mime types to an extension
-        } else if (extensionMap.get(mimeType) == null && extension != null && extension.length() > 0) {
-            extension = extension.toLowerCase();
-            this.extensionMap.put(mimeType, extension);
+            this.extensionMap.putIfAbsent(mimeType, extension);
         }
     }
 

--- a/src/main/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImpl.java
+++ b/src/main/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImpl.java
@@ -130,25 +130,21 @@ public class MimeTypeServiceImpl implements MimeTypeService, BundleListener {
 
     @Override
     public void registerMimeType(String mimeType, String... extensions) {
-        if (mimeType == null || mimeType.length() == 0 || extensions == null
-            || extensions.length == 0) {
+        if (mimeType == null || mimeType.length() == 0 || extensions == null || extensions.length == 0) {
             return;
         }
 
         mimeType = mimeType.toLowerCase();
-
         String defaultExtension = extensionMap.get(mimeType);
 
         for (String extension : extensions) {
+
             if (extension != null && extension.length() > 0) {
                 extension = extension.toLowerCase();
-
                 String oldMimeType = mimeMap.get(extension);
+
                 if (oldMimeType == null) {
-
-                    log.debug("registerMimeType: Add mapping "
-                        + extension + "=" + mimeType);
-
+                    log.debug("registerMimeType: Add mapping " + extension + "=" + mimeType);
                     this.mimeMap.put(extension, mimeType);
 
                     if (defaultExtension == null) {
@@ -156,17 +152,15 @@ public class MimeTypeServiceImpl implements MimeTypeService, BundleListener {
                     }
 
                 } else {
-
-                    log.info(
-                        "registerMimeType: Ignoring mapping " + extension + "="
-                            + mimeType + ": Mapping " + extension + "="
-                            + oldMimeType + " already exists");
-
+                    log.info("registerMimeType: Ignoring mapping " + extension + "=" + mimeType + ": Mapping "
+                        + extension + "=" + oldMimeType + " already exists");
                 }
-
             }
         }
+        addToExtensionMap(defaultExtension, mimeType, extensions);
+    }
 
+    private void addToExtensionMap(String defaultExtension, String mimeType, String[] extensions) {
         String extension = extensions[0];
         if (defaultExtension != null) {
             this.extensionMap.put(mimeType, defaultExtension);

--- a/src/main/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImpl.java
+++ b/src/main/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImpl.java
@@ -130,21 +130,25 @@ public class MimeTypeServiceImpl implements MimeTypeService, BundleListener {
 
     @Override
     public void registerMimeType(String mimeType, String... extensions) {
-        if (mimeType == null || mimeType.length() == 0 || extensions == null || extensions.length == 0) {
+        if (mimeType == null || mimeType.length() == 0 || extensions == null
+            || extensions.length == 0) {
             return;
         }
 
         mimeType = mimeType.toLowerCase();
+
         String defaultExtension = extensionMap.get(mimeType);
 
         for (String extension : extensions) {
-
             if (extension != null && extension.length() > 0) {
                 extension = extension.toLowerCase();
-                String oldMimeType = mimeMap.get(extension);
 
+                String oldMimeType = mimeMap.get(extension);
                 if (oldMimeType == null) {
-                    log.debug("registerMimeType: Add mapping " + extension + "=" + mimeType);
+
+                    log.debug("registerMimeType: Add mapping "
+                        + extension + "=" + mimeType);
+
                     this.mimeMap.put(extension, mimeType);
 
                     if (defaultExtension == null) {
@@ -152,15 +156,20 @@ public class MimeTypeServiceImpl implements MimeTypeService, BundleListener {
                     }
 
                 } else {
-                    log.info("registerMimeType: Ignoring mapping " + extension + "=" + mimeType + ": Mapping "
-                        + extension + "=" + oldMimeType + " already exists");
+
+                    log.info(
+                        "registerMimeType: Ignoring mapping " + extension + "="
+                            + mimeType + ": Mapping " + extension + "="
+                            + oldMimeType + " already exists");
+
                 }
+
             }
         }
-        addToExtensionMap(defaultExtension, mimeType, extensions);
+        addToExtensions(defaultExtension, mimeType, extensions);
     }
 
-    private void addToExtensionMap(String defaultExtension, String mimeType, String[] extensions) {
+    private void addToExtensions(String defaultExtension, String mimeType, String[] extensions) {
         String extension = extensions[0];
         if (defaultExtension != null) {
             this.extensionMap.put(mimeType, defaultExtension);

--- a/src/main/resources/META-INF/mime.types
+++ b/src/main/resources/META-INF/mime.types
@@ -24,3 +24,8 @@
 application/compress           z
 image/pict                     pict
 text/plain                     apt
+# https://en.wikipedia.org/wiki/Encapsulated_PostScript
+application/eps           eps
+application/x-eps           eps
+image/eps           eps
+image/x-eps           eps

--- a/src/test/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImplTest.java
+++ b/src/test/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImplTest.java
@@ -165,13 +165,24 @@ public class MimeTypeServiceImplTest extends TestCase {
         assertNull(this.service.getMimeType(GIF));
     }
 
-    public void testEPSMimeType() throws Exception {
+    public void testMultipleMimeTypes() throws Exception {
         loadMimeTypes(MimeTypeServiceImpl.CORE_MIME_TYPES);
         loadMimeTypes(MimeTypeServiceImpl.MIME_TYPES);
 
         for (String mm : epsMimeTypeExt.keySet()) {
             assertEquals("Extension " + mm + " (1)", epsMimeTypeExt.get(mm), this.service.getExtension(mm));
         }
+    }
+
+    public void testNegativeTests() throws Exception {
+        loadMimeTypes(MimeTypeServiceImpl.CORE_MIME_TYPES);
+        loadMimeTypes(MimeTypeServiceImpl.MIME_TYPES);
+
+        // null
+        String mm = null;
+        assertEquals("Extension " + mm + " (1)", mm, this.service.getExtension(mm));
+        mm = "";
+        assertEquals("Extension " + mm + " (1)", null, this.service.getExtension(mm));
     }
 
     private MimeTypeProvider createMimeTypeProvider(final String type, final String ext) {

--- a/src/test/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImplTest.java
+++ b/src/test/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImplTest.java
@@ -180,9 +180,12 @@ public class MimeTypeServiceImplTest extends TestCase {
 
         // null
         String mm = null;
-        assertEquals("Extension " + mm + " (1)", mm, this.service.getExtension(mm));
+        assertEquals("Extension " + mm, mm, this.service.getExtension(mm));
+        this.service.registerMimeType("application/invalid-1", mm);
         mm = "";
-        assertEquals("Extension " + mm + " (1)", null, this.service.getExtension(mm));
+        assertEquals("Extension " + mm, null, this.service.getExtension(mm));
+        this.service.registerMimeType("application/invalid-1", mm);
+        this.service.registerMimeType("application/invalid-1", "dummy");
     }
 
     private MimeTypeProvider createMimeTypeProvider(final String type, final String ext) {

--- a/src/test/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImplTest.java
+++ b/src/test/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImplTest.java
@@ -18,8 +18,6 @@ package org.apache.sling.commons.mime.internal;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.apache.sling.commons.mime.MimeTypeProvider;
 
@@ -45,16 +43,6 @@ public class MimeTypeServiceImplTest extends TestCase {
     private static final String TEXT_PLAIN = "text/plain";
 
     private static final String EPS = "eps";
-
-    private static final Map<String, String> epsMimeTypeExt = new HashMap<>();
-
-    static {
-        epsMimeTypeExt.put("application/eps", EPS);
-        epsMimeTypeExt.put("application/x-eps", EPS);
-        epsMimeTypeExt.put("image/eps", EPS);
-        epsMimeTypeExt.put("image/x-eps", EPS);
-        epsMimeTypeExt.put("application/postscript", "ai");
-    }
 
     private MimeTypeServiceImpl service;
 
@@ -169,23 +157,24 @@ public class MimeTypeServiceImplTest extends TestCase {
         loadMimeTypes(MimeTypeServiceImpl.CORE_MIME_TYPES);
         loadMimeTypes(MimeTypeServiceImpl.MIME_TYPES);
 
-        for (String mm : epsMimeTypeExt.keySet()) {
-            assertEquals("Extension " + mm + " (1)", epsMimeTypeExt.get(mm), this.service.getExtension(mm));
-        }
+        assertEquals(EPS, this.service.getExtension("application/eps"));
+        assertEquals(EPS, this.service.getExtension("application/x-eps"));
+        assertEquals(EPS, this.service.getExtension("image/x-eps"));
+        assertEquals(EPS, this.service.getExtension("image/eps"));
     }
 
     public void testNegativeTests() throws Exception {
-        loadMimeTypes(MimeTypeServiceImpl.CORE_MIME_TYPES);
-        loadMimeTypes(MimeTypeServiceImpl.MIME_TYPES);
+        // invalid values
+        String extension = null;
+        String mimeType = "application/invalid-1";
+        this.service.registerMimeType(mimeType, extension);
+        assertNull(this.service.getExtension(mimeType));
 
-        // null
-        String mm = null;
-        assertEquals("Extension " + mm, mm, this.service.getExtension(mm));
-        this.service.registerMimeType("application/invalid-1", mm);
-        mm = "";
-        assertEquals("Extension " + mm, null, this.service.getExtension(mm));
-        this.service.registerMimeType("application/invalid-1", mm);
-        this.service.registerMimeType("application/invalid-1", "dummy");
+        extension = "";
+        this.service.registerMimeType(mimeType, extension);
+        assertNull(this.service.getExtension(mimeType));
+        this.service.registerMimeType(null, extension);
+        assertNull(this.service.getExtension(null));
     }
 
     private MimeTypeProvider createMimeTypeProvider(final String type, final String ext) {

--- a/src/test/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImplTest.java
+++ b/src/test/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImplTest.java
@@ -163,7 +163,7 @@ public class MimeTypeServiceImplTest extends TestCase {
         assertEquals(EPS, this.service.getExtension("image/eps"));
     }
 
-    public void testNegativeTests() throws Exception {
+    public void testNegativeArgs() throws Exception {
         // invalid values
         String extension = null;
         String mimeType = "application/invalid-1";

--- a/src/test/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImplTest.java
+++ b/src/test/java/org/apache/sling/commons/mime/internal/MimeTypeServiceImplTest.java
@@ -18,9 +18,10 @@ package org.apache.sling.commons.mime.internal;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.sling.commons.mime.MimeTypeProvider;
-import org.apache.sling.commons.mime.internal.MimeTypeServiceImpl;
 
 import junit.framework.TestCase;
 
@@ -42,6 +43,18 @@ public class MimeTypeServiceImplTest extends TestCase {
     private static final String APT = "apt";
 
     private static final String TEXT_PLAIN = "text/plain";
+
+    private static final String EPS = "eps";
+
+    private static final Map<String, String> epsMimeTypeExt = new HashMap<>();
+
+    static {
+        epsMimeTypeExt.put("application/eps", EPS);
+        epsMimeTypeExt.put("application/x-eps", EPS);
+        epsMimeTypeExt.put("image/eps", EPS);
+        epsMimeTypeExt.put("image/x-eps", EPS);
+        epsMimeTypeExt.put("application/postscript", "ai");
+    }
 
     private MimeTypeServiceImpl service;
 
@@ -150,6 +163,15 @@ public class MimeTypeServiceImplTest extends TestCase {
         assertEquals(UNMAPPED_GIF, this.service.getExtension(IMAGE_GIF));
 
         assertNull(this.service.getMimeType(GIF));
+    }
+
+    public void testEPSMimeType() throws Exception {
+        loadMimeTypes(MimeTypeServiceImpl.CORE_MIME_TYPES);
+        loadMimeTypes(MimeTypeServiceImpl.MIME_TYPES);
+
+        for (String mm : epsMimeTypeExt.keySet()) {
+            assertEquals("Extension " + mm + " (1)", epsMimeTypeExt.get(mm), this.service.getExtension(mm));
+        }
     }
 
     private MimeTypeProvider createMimeTypeProvider(final String type, final String ext) {


### PR DESCRIPTION
- Support multiple mime types to an extension.
- Fix the sling mime type library to recognize "image/x-eps" and return extension of ".eps"
- This change will update the code to support multiple mime types for a file extension. 
- Examples : 
  - image/x-eps —> eps
  - application/x-eps —> eps

