### PR TITLE
SLING-12985 migrate to Jakarta Servlet

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,7 +1,7 @@
 Bundle-DocURL: https://sling.apache.org/site/mime-type-support.html
 
 Import-Package:\
-  javax.servlet.*;resolution:=optional,\
+  jakarta.servlet.*;resolution:=optional,\
   org.apache.felix.webconsole;resolution:=optional,\
   org.apache.tika.*;resolution:=optional,\
   *

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,18 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.20.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>org.apache.sling.commons.mime</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
 
     <name>Apache Sling Commons MIME</name>
     <description>Support for configurable MIME type mapping and querying</description>
@@ -42,6 +42,7 @@
 
     <properties>
         <sling.java.version>17</sling.java.version>
+        <slf4j.version>2.0.17</slf4j.version>
     </properties>
     <dependencies>
         <!-- OSGi -->
@@ -75,11 +76,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/apache/sling/commons/mime/internal/MimeTypeWebConsolePlugin.java
+++ b/src/main/java/org/apache/sling/commons/mime/internal/MimeTypeWebConsolePlugin.java
@@ -32,6 +32,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.sling.commons.mime.MimeTypeService;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -56,13 +57,18 @@ public class MimeTypeWebConsolePlugin extends HttpServlet {
 
     static final String CSS_REFS = RES_LOC + "/jquery.treeTable.css";
 
-    @Reference
-    private MimeTypeService mimeTypeService;
+    private final transient MimeTypeService mimeTypeService;
+
+    // SCR will inject the service via the constructor
+    @Activate
+    public MimeTypeWebConsolePlugin(@Reference MimeTypeService mimeTypeService) {
+        this.mimeTypeService = mimeTypeService;
+    }
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
 
-        Map<String, Set<String>> mimetab = new TreeMap<String, Set<String>>();
+        Map<String, Set<String>> mimetab = new TreeMap<>();
 
         Map<String, String> extMap = mimeTypeService.getExtensionMap();
 
@@ -73,7 +79,7 @@ public class MimeTypeWebConsolePlugin extends HttpServlet {
 
             Set<String> extList = mimetab.get(mime);
             if (extList == null) {
-                extList = new HashSet<String>();
+                extList = new HashSet<>();
                 mimetab.put(mime, extList);
             }
 

--- a/src/main/java/org/apache/sling/commons/mime/internal/MimeTypeWebConsolePlugin.java
+++ b/src/main/java/org/apache/sling/commons/mime/internal/MimeTypeWebConsolePlugin.java
@@ -18,11 +18,6 @@
  */
 package org.apache.sling.commons.mime.internal;
 
-import javax.servlet.Servlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URL;
@@ -32,6 +27,10 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 
+import jakarta.servlet.Servlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.sling.commons.mime.MimeTypeService;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;

--- a/src/test/java/org/apache/sling/commons/mime/internal/MimeTypeWebConsolePluginTest.java
+++ b/src/test/java/org/apache/sling/commons/mime/internal/MimeTypeWebConsolePluginTest.java
@@ -37,27 +37,16 @@ import static org.mockito.Mockito.when;
  */
 public class MimeTypeWebConsolePluginTest {
 
-    private void loadMimeTypes(MimeTypeServiceImpl service, String path) throws IOException {
-        InputStream ins = this.getClass().getResourceAsStream(path);
-        assertNotNull(ins);
-
-        try {
-            service.registerMimeType(ins);
-        } finally {
-            try {
-                ins.close();
-            } catch (IOException ignore) {
-            }
-        }
-    }
-
     /**
      * Test method for {@link org.apache.sling.commons.mime.internal.MimeTypeWebConsolePlugin#doGet(jakarta.servlet.http.HttpServletRequest, jakarta.servlet.http.HttpServletResponse)}.
      */
     @Test
     public void testDoGet() throws IOException {
         final MimeTypeServiceImpl service = new MimeTypeServiceImpl();
-        loadMimeTypes(service, MimeTypeServiceImpl.CORE_MIME_TYPES);
+        try (InputStream ins = this.getClass().getResourceAsStream(MimeTypeServiceImpl.CORE_MIME_TYPES)) {
+            assertNotNull(ins);
+            service.registerMimeType(ins);
+        }
 
         final MimeTypeWebConsolePlugin plugin = new MimeTypeWebConsolePlugin(service);
         assertNotNull(plugin);

--- a/src/test/java/org/apache/sling/commons/mime/internal/MimeTypeWebConsolePluginTest.java
+++ b/src/test/java/org/apache/sling/commons/mime/internal/MimeTypeWebConsolePluginTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.commons.mime.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ *
+ */
+public class MimeTypeWebConsolePluginTest {
+
+    private void loadMimeTypes(MimeTypeServiceImpl service, String path) throws IOException {
+        InputStream ins = this.getClass().getResourceAsStream(path);
+        assertNotNull(ins);
+
+        try {
+            service.registerMimeType(ins);
+        } finally {
+            try {
+                ins.close();
+            } catch (IOException ignore) {
+            }
+        }
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.commons.mime.internal.MimeTypeWebConsolePlugin#doGet(jakarta.servlet.http.HttpServletRequest, jakarta.servlet.http.HttpServletResponse)}.
+     */
+    @Test
+    public void testDoGet() throws IOException {
+        final MimeTypeServiceImpl service = new MimeTypeServiceImpl();
+        loadMimeTypes(service, MimeTypeServiceImpl.CORE_MIME_TYPES);
+
+        final MimeTypeWebConsolePlugin plugin = new MimeTypeWebConsolePlugin(service);
+        assertNotNull(plugin);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        when(response.getWriter()).thenReturn(pw);
+
+        plugin.doGet(request, response);
+        pw.flush();
+        String output = sw.toString();
+
+        // Assert: basic expected content is present
+        assertTrue("Output should contain a table element", output.contains("<table id='mimetabtable'"));
+    }
+}


### PR DESCRIPTION
bump bundle major version to 3.0.0
bump slf4j-api to the 2.x version
migrate the javax.servlet references to jakarta.servlet